### PR TITLE
PLT-102 fix: handle all documented network timeout errors

### DIFF
--- a/lib/svelte/rest_client.rb
+++ b/lib/svelte/rest_client.rb
@@ -24,7 +24,11 @@ module Svelte
         connection.send verb, url, params, headers do |request|
           request.options.timeout = options[:timeout] if options[:timeout]
         end
-      rescue Faraday::TimeoutError => e
+      # https://github.com/lostisland/faraday-retry#specify-which-exceptions-should-trigger-a-retry
+      # Network timeouts may raise either of these three errors. Not handling them may result in really weird bugs, see
+      # https://www.schneems.com/2017/02/21/the-oldest-bug-in-ruby-why-racktimeout-might-hose-your-server/
+      # https://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-thread-dot-raise-is-terrifying/
+      rescue Faraday::TimeoutError, Errno::ETIMEDOUT, Timeout::Error => e
         raise HTTPError.new(parent: e)
       rescue Faraday::ConnectionFailed => e
         raise HTTPError.new(parent: e)


### PR DESCRIPTION
I suspect that the Equifax client is behind the weird filesystem errors we're experiencing (see the full writeup https://www.notion.so/meetcleo/What-is-happening-with-LoadErrors-3b70578534974a0cbac882cd5c44c200).

tl;dr - improperly handled timeouts can cause this. A brief inspection showed that Svelte is not handling the documented errors that can be raised from network timeouts (https://github.com/lostisland/faraday-retry#specify-which-exceptions-should-trigger-a-retry).

We're handling them like this in the Tabapay client, so it's worth a shot.